### PR TITLE
implement chained scrollbars

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,24 @@ the inspiration to this, and some handy implementation hints, came.
         return '<img src="http://latex.codecogs.com/png.latex?' + encodeURIComponent(b) + '" />';
       });
 
-      document.getElementById('out').innerHTML = marked(val);
+      var out = document.getElementById('out');
+      var old = out.cloneNode(true);
+      out.innerHTML = marked(val);
+
+      var allold = old.getElementsByTagName("*");
+      if (allold === undefined) {
+        return;
+      }
+      var allnew = out.getElementsByTagName("*");
+      if (allnew === undefined) {
+        return;
+      }
+      for (var i = 0, max = Math.min(allold.length, allnew.length); i < max; i++) {
+        if (!allold[i].isEqualNode(allnew[i])) {
+          out.scrollTop = allnew[i].offsetTop;
+          return;
+        }
+      }
     }
 
     var editor = CodeMirror.fromTextArea(document.getElementById('code'), {


### PR DESCRIPTION
fixes issue #4 (chained scrollbars)

Updates out div only on change, scrolling with scrollbars is free which is a big plus for me.
I want to see when I type / delete something in source document, otherwise I want to
freely scroll either in source or in preview panel.
The chain is exact, so it doesn't unsync on documents with too much new lines, captions, pictures etc.. like other web-based markdown editors do.
