### PR TITLE
Add print styles for output printing from browser (Ctrl+P)

### DIFF
--- a/index.html
+++ b/index.html
@@ -200,6 +200,19 @@
     table { border-collapse: collapse; border-spacing: 0; }
     td, th { vertical-align: top; padding: 4px 10px; border: 1px solid #bbb; }
     tr:nth-child(even) td, tr:nth-child(even) th { background: #eee; }
+
+    @media print {
+      #in {
+        display: none;  
+        width: 0;
+      }
+
+      #out {
+        position: static;
+        left: 0;
+        width: 100%;
+      }
+    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
With these few lines of CSS, you will able to print out the output of the editor.

Just hit Ctrl+P and you will only see the only the output on the print preview. Same formatting as in the editor, but the input (markdown format) is not on the paper(s)
