### PR TITLE
Fix grammar issue in navbar link title

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,7 +43,7 @@
         <p id="openbutton" title="Open from Disk" class="navbutton left" onclick="document.getElementById('fileInput').click();"><i class="material-icons">open_in_browser</i></p>
         <input id="fileInput" type="file" class="hidden" accept=".md,.mdown,.txt,.markdown"/>
         <p id="savebutton" title="Download" class="navbutton left" onclick="showMenu()"><i class="material-icons">file_download</i></p>
-        <p id="browsersavebutton" title="Browser Save(Experimental)" class="navbutton left" onclick="saveInBrowser()"><i class="material-icons">save</i></p>
+        <p id="browsersavebutton" title="Browser Save (Experimental)" class="navbutton left" onclick="saveInBrowser()"><i class="material-icons">save</i></p>
         <p id="sharebutton" title="Generate Shareable Link" class="navbutton left" onclick="updateHash()"><i class="material-icons">share</i></p>
         <p id="nightbutton" title="Night Mode" class="navbutton left" onclick="toggleNightMode(this)"><i class="material-icons">invert_colors</i></p>
         <p id="readbutton" title="Reading Mode" class="navbutton left" onclick="toggleReadMode(this)"><i class="material-icons">chrome_reader_mode</i></p>


### PR DESCRIPTION
The hover title of the browser save icon is `Browser Save(Experimental)`, and it should be `Browser Save[ ](Experimental)`.
According to a [Stack Exchange English Language post](https://english.stackexchange.com/questions/5987/is-there-any-rule-for-the-placement-of-space-after-and-before-parentheses), adding a space before parentheses can increase readability.