### PR TITLE
Added code to enable the ability to detect and render Task Lists

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,15 +59,15 @@ User: @austinmm
 */
 var render_tasklist = function(str){
     // Checked task-list box match
-	if(str.match(/<li>\[x\]\s+\w+<\/li>/gi)){
-        str = str.replace(/(<li)(>\[x\]\s+)(\w+<\/li>)/gi, 
+	if(str.match(/<li>\[x\]\s+\w+/gi)){
+        str = str.replace(/(<li)(>\[x\]\s+)(\w+)/gi, 
           `$1 style="list-style-type: none;"><input type="checkbox" 
           checked style="list-style-type: none; 
           margin: 0 0.2em 0 -1.3em;" disabled> $3`);
     }
     // Unchecked task-list box match
-    if (str.match(/<li>\[ \]\s+\w+<\/li>/gi)){
-        str = str.replace(/(<li)(>\[ \]\s+)(\w+<\/li>)/gi, 
+    if (str.match(/<li>\[ \]\s+\w+/gi)){
+        str = str.replace(/(<li)(>\[ \]\s+)(\w+)/gi, 
           `$1 style="list-style-type: none;"><input type="checkbox" 
             style="list-style-type: none; 
             margin: 0 0.2em 0 -1.3em;" disabled> $3`);

--- a/index.js
+++ b/index.js
@@ -55,11 +55,34 @@ function setOutput(val) {
     val = val.replace(/<equation>((.*?\n)*?.*?)<\/equation>/ig, function(a, b) {
         return '<img src="http://latex.codecogs.com/png.latex?' + encodeURIComponent(b) + '" />';
     });
-
+    /*
+    val = val.replace(/- [(.)] (\w+)/gi, function(x, a, b){
+        var icon_html = '<input type="checkbox" ';
+        icon_html += (a == ' ')? 'checked style="margin: 0 0.2em 0 -1.3em;">': 'style="list-style-type: none;">';
+        return '<input type="checkbox" '+a+b+'<br />';
+    });
+    */
     var out = document.getElementById('out');
     var old = out.cloneNode(true);
     out.innerHTML = md.render(val);
     emojify.run(out);
+    console.log(out.innerHTML);
+    if(out.innerHTML.match(/(<li)(>\[x\] )(\w+<\/li>)/)){
+        out.innerHTML = out.innerHTML.replace(/(<li)(>\[x\] )(\w+<\/li>)/, `
+        $1 style="list-style-type: none;">
+        <input type="checkbox" checked 
+        style="list-style-type: none; 
+        margin: 0 0.2em 0 -1.3em;"> $3`
+        );
+    }
+    if(out.innerHTML.match(/(<li)(>\[ \] )(\w+<\/li>)/)){
+        out.innerHTML = out.innerHTML.replace(/(<li)(>\[ \] )(\w+<\/li>)/, `
+        $1 style="list-style-type: none;">
+        <input type="checkbox" 
+        style="list-style-type: none; 
+        margin: 0 0.2em 0 -1.3em;"> $3`
+        );
+    }
 
     var allold = old.getElementsByTagName("*");
     if (allold === undefined) return;

--- a/index.js
+++ b/index.js
@@ -51,38 +51,42 @@ function update(e) {
     //hashto = setTimeout(updateHash, 1000);
 }
 
+/*
+This function is used to check for task list notation.
+If regex matches the string to task-list markdown format,
+then the task-list is rendered to its correct form.
+User: @austinmm
+*/
+var render_tasklist = function(str){
+    // Checked task-list box match
+	if(str.match(/<li>\[x\]\s+\w+<\/li>/gi)){
+        str = str.replace(/(<li)(>\[x\]\s+)(\w+<\/li>)/gi, 
+          `$1 style="list-style-type: none;"><input type="checkbox" 
+          checked style="list-style-type: none; 
+          margin: 0 0.2em 0 -1.3em;" disabled> $3`);
+    }
+    // Unchecked task-list box match
+    if (str.match(/<li>\[ \]\s+\w+<\/li>/gi)){
+        str = str.replace(/(<li)(>\[ \]\s+)(\w+<\/li>)/gi, 
+          `$1 style="list-style-type: none;"><input type="checkbox" 
+            style="list-style-type: none; 
+            margin: 0 0.2em 0 -1.3em;" disabled> $3`);
+    }
+    return str
+}
+
 function setOutput(val) {
     val = val.replace(/<equation>((.*?\n)*?.*?)<\/equation>/ig, function(a, b) {
         return '<img src="http://latex.codecogs.com/png.latex?' + encodeURIComponent(b) + '" />';
     });
-    /*
-    val = val.replace(/- [(.)] (\w+)/gi, function(x, a, b){
-        var icon_html = '<input type="checkbox" ';
-        icon_html += (a == ' ')? 'checked style="margin: 0 0.2em 0 -1.3em;">': 'style="list-style-type: none;">';
-        return '<input type="checkbox" '+a+b+'<br />';
-    });
-    */
+
     var out = document.getElementById('out');
     var old = out.cloneNode(true);
     out.innerHTML = md.render(val);
     emojify.run(out);
     console.log(out.innerHTML);
-    if(out.innerHTML.match(/(<li)(>\[x\] )(\w+<\/li>)/)){
-        out.innerHTML = out.innerHTML.replace(/(<li)(>\[x\] )(\w+<\/li>)/, `
-        $1 style="list-style-type: none;">
-        <input type="checkbox" checked 
-        style="list-style-type: none; 
-        margin: 0 0.2em 0 -1.3em;"> $3`
-        );
-    }
-    if(out.innerHTML.match(/(<li)(>\[ \] )(\w+<\/li>)/)){
-        out.innerHTML = out.innerHTML.replace(/(<li)(>\[ \] )(\w+<\/li>)/, `
-        $1 style="list-style-type: none;">
-        <input type="checkbox" 
-        style="list-style-type: none; 
-        margin: 0 0.2em 0 -1.3em;"> $3`
-        );
-    }
+    // Checks if there are any task-list present in out.innerHTML
+    out.innerHTML = render_tasklist(out.innerHTML);
 
     var allold = old.getElementsByTagName("*");
     if (allold === undefined) return;


### PR DESCRIPTION
This pull request should solve open issue #88. I added a function in `index.js`, which uses Regex to match and replace the task list syntax to its proper HTML form. The reason that task lists were not already supported was due to [markdown-it](https://github.com/markdown-it/markdown-it), which markdown-editor uses to render the markdown syntax into HTML, does not currently support this feature.